### PR TITLE
Route /bench/ to bench-api on api.swecc.org

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -114,6 +114,45 @@ http {
             return 503 '{"status":"error","message":"WebSocket service unavailable"}';
         }
 
+        # ── bench-api (BenchAnything FastAPI) ──────────────────────────────
+        # Public URLs:
+        #   GET    https://api.swecc.org/bench/v1/domains
+        #   POST   https://api.swecc.org/bench/v1/runs
+        #   WS     wss://api.swecc.org/bench/v1/ws/episodes/{id}/trace
+        #   GET    https://api.swecc.org/bench/docs   (FastAPI /docs)
+        #
+        # Strips /bench/ before forwarding (bench-api sees /v1/..., /docs, /health).
+        # rewrite + variable upstream — trailing slash on proxy_pass is invalid here.
+
+        location /bench/v1/ws/ {
+            set $upstream_bench bench-api;
+            rewrite ^/bench/(.*)$ /$1 break;
+            proxy_pass http://$upstream_bench:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+            proxy_send_timeout 86400;
+            proxy_buffering off;
+        }
+
+        location /bench/ {
+            set $upstream_bench bench-api;
+            rewrite ^/bench/(.*)$ /$1 break;
+            proxy_pass http://$upstream_bench:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 600;
+            proxy_send_timeout 600;
+            chunked_transfer_encoding on;
+        }
+
         # All other API requests
         location / {
             set $upstream_api server;


### PR DESCRIPTION
## Summary

- Add nginx `location` blocks for `/bench/` and `/bench/v1/ws/` on `api.swecc.org`, proxying to the `bench-api` swarm service (same pattern as swecc-core `infra/nginx.conf`).
- Strip the `/bench/` prefix before forwarding so bench-api receives `/health`, `/v1/domains`, `/docs`, etc.
- Completes the prod wiring for the mesocosm UI, which calls `https://api.swecc.org/bench` (PR #12 only synced swarm env configs).

## Test plan

- [ ] On the swarm manager after merge: pull this `nginx.conf` and redeploy the nginx stack (`docker stack deploy -c stack.yml …`).
- [ ] `curl -sS https://api.swecc.org/bench/health` → `{"status":"ok","version":"0.1.0"}`
- [ ] `curl -sS https://api.swecc.org/bench/v1/domains` → JSON (200), not Django HTML 404
- [ ] Open https://swecc-uw.github.io/swecc-mesocosm/ — gallery loads domains
- [ ] If 502 on `/bench/*`: confirm `bench-api` swarm service is running; redeploy via swecc-core `deploy-bench-api.yml` if needed


Made with [Cursor](https://cursor.com)