### PR TITLE
Add deploy-nginx workflow for swecc_stack

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -1,0 +1,64 @@
+name: Deploy Nginx Stack
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'nginx.conf'
+      - 'stack.yml'
+      - '.github/workflows/deploy-nginx.yml'
+  workflow_dispatch:
+
+env:
+  STACK_NAME: swecc_stack
+  SERVICE_NAME: swecc_stack_nginx
+
+jobs:
+  deploy_to_swarm:
+    name: Deploy to Swarm
+    runs-on:
+      group: EC2
+      labels: [self-hosted, deploy]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Deploy nginx stack
+        run: |
+          docker stack deploy -c stack.yml --with-registry-auth --prune ${{ env.STACK_NAME }}
+
+          echo "Stack deployed. Current services:"
+          docker service ls
+
+      - name: Verify deployment
+        run: |
+          echo "Waiting for nginx service to stabilize..."
+          sleep 5
+
+          timeout=120
+          elapsed=0
+
+          while [ $elapsed -lt $timeout ]; do
+            if ! docker service inspect ${{ env.SERVICE_NAME }} &>/dev/null; then
+              echo "⏳ Service ${{ env.SERVICE_NAME }} not found yet..."
+            else
+              REPLICAS=$(docker service ls --filter "name=${{ env.SERVICE_NAME }}" --format "{{.Replicas}}")
+              echo "Current replica status: $REPLICAS"
+
+              if echo "$REPLICAS" | grep -qv "0/"; then
+                echo "✅ Nginx stack deployed successfully"
+                exit 0
+              fi
+            fi
+
+            echo "⏳ Waiting... ($elapsed/$timeout seconds)"
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          echo "❌ Deployment verification timed out"
+          docker service ps ${{ env.SERVICE_NAME }} --no-trunc 2>/dev/null || docker service ls
+          exit 1


### PR DESCRIPTION
## Summary
- Adds `deploy-nginx.yml` to deploy `stack.yml` / `nginx.conf` to the EC2 swarm on push to `main` or manual dispatch.
- Uses stack name `swecc_stack` (same as the removed historical deploy workflow).

## Test plan
- [ ] Merge and confirm **Deploy Nginx Stack** workflow runs on `main`
- [ ] Or run **Deploy Nginx Stack** manually from Actions after merge
- [ ] `curl -sS https://api.swecc.org/bench/health` → `{"status":"ok","version":"0.1.0"}`


Made with [Cursor](https://cursor.com)