### PR TITLE
Sync nginx.conf to prod_nginx bind mount on deploy

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
-      - name: Reload prod nginx
+      - name: Sync nginx.conf to prod bind mount
         run: |
           set -euo pipefail
+          # shellcheck source=scripts/nginx-mount-path.sh
+          . ./scripts/nginx-mount-path.sh
 
           if ! docker service inspect "${{ env.SERVICE_NAME }}" &>/dev/null; then
             echo "❌ Service ${{ env.SERVICE_NAME }} not found on this swarm."
@@ -34,7 +36,13 @@ jobs:
             exit 1
           fi
 
-          echo "Updating ${{ env.SERVICE_NAME }} (bind-mounted nginx.conf from this checkout)..."
+          sync_nginx_conf_to_service_mount "${{ env.SERVICE_NAME }}" nginx.conf
+
+      - name: Reload prod nginx
+        run: |
+          set -euo pipefail
+
+          echo "Reloading ${{ env.SERVICE_NAME }}..."
           docker service update \
             --force \
             --update-parallelism 1 \

--- a/scripts/nginx-mount-path.sh
+++ b/scripts/nginx-mount-path.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shared helpers: resolve prod nginx bind-mount source and sync nginx.conf there.
+set -euo pipefail
+
+NGINX_CONF_TARGET="${NGINX_CONF_TARGET:-/etc/nginx/nginx.conf}"
+
+# Swarm inspect may return Docker Desktop's /host_mnt/... prefix; map to a host path we can write.
+host_path_from_mount_source() {
+  local p="$1"
+  p="${p#/host_mnt}"
+  if [[ -e "$p" ]]; then
+    printf '%s' "$p"
+    return 0
+  fi
+  # macOS: /var/... is often /private/var/...
+  if [[ "$p" == /private/* && -e "${p#/private}" ]]; then
+    printf '%s' "${p#/private}"
+    return 0
+  fi
+  printf '%s' "$p"
+}
+
+# Print the host path bind-mounted to NGINX_CONF_TARGET for a Swarm service.
+nginx_bind_mount_source() {
+  local service_name="${1:?service name required}"
+  local mounts_json
+  mounts_json="$(docker service inspect "$service_name" \
+    --format '{{json .Spec.TaskTemplate.ContainerSpec.Mounts}}' 2>/dev/null || echo 'null')"
+
+  if [[ "$mounts_json" == "null" || "$mounts_json" == "[]" || -z "$mounts_json" ]]; then
+    echo "ERROR: no mounts on service $service_name" >&2
+    return 1
+  fi
+
+  # Prefer jq when available; fall back to a minimal grep/sed parser.
+  if command -v jq >/dev/null 2>&1; then
+    local source
+    source="$(printf '%s' "$mounts_json" | jq -r --arg t "$NGINX_CONF_TARGET" \
+      '.[] | select(.Type == "bind" and .Target == $t) | .Source' | head -n1)"
+    if [[ -n "$source" && "$source" != "null" ]]; then
+      printf '%s' "$source"
+      return 0
+    fi
+  else
+    local source
+    source="$(printf '%s' "$mounts_json" | tr ',' '\n' \
+      | grep -F "\"Target\":\"$NGINX_CONF_TARGET\"" \
+      | sed -n 's/.*"Source":"\([^"]*\)".*/\1/p' | head -n1)"
+    if [[ -n "$source" ]]; then
+      printf '%s' "$source"
+      return 0
+    fi
+  fi
+
+  echo "ERROR: no bind mount found for target $NGINX_CONF_TARGET on $service_name" >&2
+  echo "Mounts: $mounts_json" >&2
+  return 1
+}
+
+# Copy repo nginx.conf to the path the running service actually reads.
+sync_nginx_conf_to_service_mount() {
+  local service_name="${1:?service name required}"
+  local source_conf="${2:-nginx.conf}"
+
+  if [[ ! -f "$source_conf" ]]; then
+    echo "ERROR: $source_conf not found" >&2
+    return 1
+  fi
+
+  local mount_source host_path
+  mount_source="$(nginx_bind_mount_source "$service_name")"
+  host_path="$(host_path_from_mount_source "$mount_source")"
+
+  echo "Service: $service_name"
+  echo "Mount source (inspect): $mount_source"
+  echo "Host path (write): $host_path"
+  echo "Copying $source_conf -> $host_path"
+
+  mkdir -p "$(dirname "$host_path")"
+  cp "$source_conf" "$host_path"
+
+  if ! grep -q 'location /bench/' "$host_path"; then
+    echo "ERROR: synced file missing /bench/ routes" >&2
+    return 1
+  fi
+
+  echo "OK: synced nginx.conf includes /bench/ routes"
+}

--- a/scripts/verify-nginx-deploy-local.sh
+++ b/scripts/verify-nginx-deploy-local.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Local verification for nginx bind-mount deploy behavior.
+#
+#   ./scripts/verify-nginx-deploy-local.sh --unit     # no Docker daemon
+#   ./scripts/verify-nginx-deploy-local.sh --swarm    # full Swarm repro (needs Docker)
+#   ./scripts/verify-nginx-deploy-local.sh            # unit + swarm if Docker is up
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/nginx-mount-path.sh
+. "$ROOT/scripts/nginx-mount-path.sh"
+
+STACK_NAME="verify_nginx_mount"
+SERVICE_NAME="${STACK_NAME}_nginx"
+FAILED=0
+LE_DIR=""
+
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; FAILED=1; }
+
+# Docker Desktop on macOS reports bind sources under /host_mnt/...
+canonical_path() {
+  local p="$1"
+  p="${p#/host_mnt}"
+  if [[ -e "$p" ]]; then
+    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$p"
+  else
+    printf '%s' "$p"
+  fi
+}
+
+paths_equal() {
+  [[ "$(canonical_path "$1")" == "$(canonical_path "$2")" ]]
+}
+
+prepare_stub_tls() {
+  LE_DIR="$(mktemp -d)"
+  mkdir -p "$LE_DIR/live/api.swecc.org"
+  openssl req -x509 -nodes -newkey rsa:2048 \
+    -keyout "$LE_DIR/live/api.swecc.org/privkey.pem" \
+    -out "$LE_DIR/live/api.swecc.org/fullchain.pem" \
+    -days 1 -subj "/CN=api.swecc.org" 2>/dev/null
+}
+
+run_unit_tests() {
+  echo "=== Unit tests (mock docker service inspect) ==="
+
+  local mock_json='[{"Type":"bind","Source":"/tmp/old-checkout/nginx.conf","Target":"/etc/nginx/nginx.conf","ReadOnly":true}]'
+  local got
+  got="$(printf '%s' "$mock_json" | jq -r --arg t "$NGINX_CONF_TARGET" \
+    '.[] | select(.Type == "bind" and .Target == $t) | .Source' | head -n1)"
+  if [[ "$got" == "/tmp/old-checkout/nginx.conf" ]]; then
+    pass "jq extracts bind mount source"
+  else
+    fail "jq extract got '$got'"
+  fi
+
+  if grep -q 'location /bench/' "$ROOT/nginx.conf"; then
+    pass "repo nginx.conf contains /bench/ routes"
+  else
+    fail "repo nginx.conf missing /bench/ routes"
+  fi
+
+  echo ""
+  echo "=== nginx -t (config syntax) ==="
+  if docker_ready; then
+    prepare_stub_tls
+    if docker run --rm \
+      -v "$ROOT/nginx.conf:/etc/nginx/nginx.conf:ro" \
+      -v "$LE_DIR:/etc/letsencrypt:ro" \
+      nginx:stable-alpine nginx -t 2>&1; then
+      pass "nginx -t"
+    else
+      fail "nginx -t"
+    fi
+    rm -rf "$LE_DIR"
+    LE_DIR=""
+  else
+    echo "SKIP: docker daemon unavailable — start Docker Desktop, then re-run"
+  fi
+}
+
+docker_ready() {
+  perl -e 'alarm 8; exec @ARGV' docker info >/dev/null 2>&1
+}
+
+run_swarm_repro() {
+  echo ""
+  echo "=== Swarm repro: checkout path != mount path ==="
+
+  if ! docker_ready; then
+    echo "SKIP: Docker daemon not reachable (start Docker Desktop and re-run with --swarm)"
+    return 0
+  fi
+
+  docker swarm init --advertise-addr 127.0.0.1 2>/dev/null || true
+  docker stack rm -f "$STACK_NAME" 2>/dev/null || true
+  docker service rm "$SERVICE_NAME" 2>/dev/null || true
+  sleep 3
+
+  prepare_stub_tls
+
+  local dir_a dir_b
+  dir_a="$(mktemp -d)"
+  dir_b="$(mktemp -d)"
+  cleanup_swarm_test() {
+    docker stack rm -f "$STACK_NAME" 2>/dev/null || true
+    rm -rf "$dir_a" "$dir_b" "$LE_DIR"
+    LE_DIR=""
+  }
+
+  cp "$ROOT/nginx.conf" "$dir_a/nginx.conf"
+  cp "$ROOT/nginx.conf" "$dir_b/nginx.conf"
+
+  # Marker A: only in dir_a file at deploy time
+  echo "# VERIFY_MARKER_A" >> "$dir_a/nginx.conf"
+  echo "# VERIFY_MARKER_B" >> "$dir_b/nginx.conf"
+
+  mkdir -p "$dir_a/html"
+  cat >"$dir_a/stack.yml" <<EOF
+version: '3.8'
+services:
+  nginx:
+    image: nginx:stable-alpine
+    volumes:
+      - ${LE_DIR}:/etc/letsencrypt:ro
+      - \${PWD}/html:/usr/share/nginx/html:ro
+      - \${PWD}/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "18080:80"
+      - "18443:443"
+networks:
+  default:
+    driver: overlay
+EOF
+
+  (
+    cd "$dir_a"
+    docker stack deploy -c stack.yml "$STACK_NAME"
+  )
+
+  echo "Waiting for nginx task..."
+  local i
+  for i in $(seq 1 30); do
+    if docker service ls --filter "name=${SERVICE_NAME}" --format '{{.Replicas}}' 2>/dev/null | grep -q '1/1'; then
+      break
+    fi
+    sleep 2
+  done
+
+  local mount_source
+  mount_source="$(nginx_bind_mount_source "$SERVICE_NAME")"
+  pass "resolved mount source: $mount_source"
+
+  if ! paths_equal "$mount_source" "$dir_a/nginx.conf"; then
+    fail "expected mount $dir_a/nginx.conf got $mount_source"
+  else
+    pass "mount path matches deploy-time PWD (normalized)"
+  fi
+
+  wait_for_nginx_container() {
+    local cid=""
+    for _ in $(seq 1 30); do
+      cid="$(docker ps -q --filter "name=${STACK_NAME}_nginx" --filter "status=running" | head -n1)"
+      if [[ -n "$cid" ]]; then
+        printf '%s' "$cid"
+        return 0
+      fi
+      sleep 2
+    done
+    return 1
+  }
+
+  local container_id marker
+  container_id="$(wait_for_nginx_container)" || true
+  if [[ -z "$container_id" ]]; then
+    fail "no running nginx container"
+    return
+  fi
+
+  marker="$(docker exec "$container_id" grep -o 'VERIFY_MARKER_[AB]' /etc/nginx/nginx.conf | head -n1 || true)"
+  if [[ "$marker" == "VERIFY_MARKER_A" ]]; then
+    pass "without sync: container still reads dir_a config (marker A)"
+  else
+    fail "without sync: expected VERIFY_MARKER_A in container, got '$marker'"
+  fi
+
+  # Apply fix: copy from dir_b (simulated checkout) to frozen mount path
+  sync_nginx_conf_to_service_mount "$SERVICE_NAME" "$dir_b/nginx.conf"
+
+  # Bind mounts are live — no stack update required for the file to change in-container.
+  container_id="$(wait_for_nginx_container)" || true
+  marker="$(docker exec "$container_id" grep -o 'VERIFY_MARKER_[AB]' /etc/nginx/nginx.conf | head -n1 || true)"
+  if [[ "$marker" == "VERIFY_MARKER_B" ]]; then
+    pass "with sync: container reads updated config (marker B)"
+  else
+    fail "with sync: expected VERIFY_MARKER_B in container, got '$marker'"
+  fi
+
+  cleanup_swarm_test
+}
+
+MODE="${1:---all}"
+case "$MODE" in
+  --unit) run_unit_tests ;;
+  --swarm) run_swarm_repro ;;
+  --all|*)
+    run_unit_tests
+    run_swarm_repro
+    ;;
+esac
+
+echo ""
+if [[ "$FAILED" -eq 0 ]]; then
+  echo "All checks passed."
+  exit 0
+fi
+echo "Some checks failed."
+exit 1

--- a/scripts/verify-nginx-deploy-local.sh
+++ b/scripts/verify-nginx-deploy-local.sh
@@ -104,10 +104,12 @@ run_swarm_repro() {
   dir_a="$(mktemp -d)"
   dir_b="$(mktemp -d)"
   cleanup_swarm_test() {
+    trap - EXIT
     docker stack rm -f "$STACK_NAME" 2>/dev/null || true
     rm -rf "$dir_a" "$dir_b" "$LE_DIR"
     LE_DIR=""
   }
+  trap cleanup_swarm_test EXIT
 
   cp "$ROOT/nginx.conf" "$dir_a/nginx.conf"
   cp "$ROOT/nginx.conf" "$dir_b/nginx.conf"


### PR DESCRIPTION
## Summary
- Adds `scripts/nginx-mount-path.sh` to resolve `prod_nginx`'s bind-mount host path and copy `nginx.conf` there before reload.
- Splits deploy into **sync** then **docker service update --force** (PR #16 only reloaded the container; checkout did not update the frozen mount path).

## Why
`/bench/*` on production still returned Django 404 after Deploy Nginx succeeded because `prod_nginx` reads a host file path set at original stack deploy, not the Actions checkout directory.

## Revert note
No need to revert merged PRs #13–#16:
- **#13** — `/bench/` routes in `nginx.conf` (keep)
- **#14–#15** — superseded by #16 (harmless)
- **#16** — correct `prod_nginx` target; this PR completes it with mount sync

## Test plan
- [ ] Merge and run **Deploy Nginx** workflow on EC2
- [ ] `curl https://api.swecc.org/bench/health` returns FastAPI JSON (not Django 404)