### PR TITLE
Match prod nginx to SWAG swecc_stack_* upstreams

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -38,6 +38,19 @@ jobs:
 
           sync_nginx_conf_to_service_mount "${{ env.SERVICE_NAME }}" nginx.conf
 
+      - name: Attach prod nginx to app overlay network
+        run: |
+          set -euo pipefail
+          APP_NETWORK="${APP_NETWORK:-prod_swecc-network}"
+          if docker service inspect "${{ env.SERVICE_NAME }}" \
+            --format '{{range .Spec.TaskTemplate.Networks}}{{.Target}}{{println}}{{end}}' \
+            | grep -qx "$APP_NETWORK"; then
+            echo "✅ ${{ env.SERVICE_NAME }} already on $APP_NETWORK"
+          else
+            echo "Adding $APP_NETWORK to ${{ env.SERVICE_NAME }}..."
+            docker service update --network-add "name=${APP_NETWORK}" "${{ env.SERVICE_NAME }}"
+          fi
+
       - name: Reload prod nginx
         run: |
           set -euo pipefail

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,9 +50,9 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
         ssl_prefer_server_ciphers on;
 
-        # Health check endpoint
+        # Health check endpoint (upstream names match SWAG / swarm stack DNS)
         location /health/ {
-            set $upstream_server server;
+            set $upstream_server swecc_stack_server;
             proxy_pass http://$upstream_server:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -74,7 +74,7 @@ http {
 
         # WebSocket endpoint - exact match for /ws
         location = /ws {
-            set $upstream_ws sockets;
+            set $upstream_ws swecc_stack_sockets;
             proxy_pass http://$upstream_ws:8004;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -92,7 +92,7 @@ http {
 
         # WebSocket endpoint - all paths under /ws/
         location /ws/ {
-            set $upstream_ws sockets;
+            set $upstream_ws swecc_stack_sockets;
             proxy_pass http://$upstream_ws:8004;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -121,11 +121,11 @@ http {
         #   WS     wss://api.swecc.org/bench/v1/ws/episodes/{id}/trace
         #   GET    https://api.swecc.org/bench/docs   (FastAPI /docs)
         #
-        # Strips /bench/ before forwarding (bench-api sees /v1/..., /docs, /health).
-        # rewrite + variable upstream — trailing slash on proxy_pass is invalid here.
+        # Upstreams: swecc_stack_* (same hostnames as swecc-core infra/gateway SWAG).
+        # /bench/v1/ws/ uses rewrite; /bench/ uses trailing slash on proxy_pass (SWAG style).
 
         location /bench/v1/ws/ {
-            set $upstream_bench bench-api;
+            set $upstream_bench swecc_stack_bench-api;
             rewrite ^/bench/(.*)$ /$1 break;
             proxy_pass http://$upstream_bench:8000;
             proxy_http_version 1.1;
@@ -141,21 +141,18 @@ http {
         }
 
         location /bench/ {
-            set $upstream_bench bench-api;
-            rewrite ^/bench/(.*)$ /$1 break;
-            proxy_pass http://$upstream_bench:8000;
+            proxy_pass http://swecc_stack_bench-api:8000/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 600;
             proxy_send_timeout 600;
-            chunked_transfer_encoding on;
         }
 
         # All other API requests
         location / {
-            set $upstream_api server;
+            set $upstream_api swecc_stack_server;
             proxy_pass http://$upstream_api:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/stack.yml
+++ b/stack.yml
@@ -16,12 +16,12 @@ services:
       - 80:80
       - 443:443
     networks:
-      - swecc-network
+      # App services from swecc-core deploy on prod_swecc-network; nginx must share it.
+      - prod_swecc-network
 
 networks:
-  swecc-network:
-    driver: overlay
-    attachable: true
+  prod_swecc-network:
+    external: true
 
 volumes:
   chronos_data:


### PR DESCRIPTION
## Summary

Updates live `prod_nginx` config to use the same upstream hostnames as SWAG in swecc-core (`swecc_stack_server`, `swecc_stack_sockets`, `swecc_stack_bench-api`).

## Changes

- `nginx.conf` — SWAG-aligned routes; `/bench/` uses `proxy_pass http://swecc_stack_bench-api:8000/;`
- `stack.yml` — nginx on external `prod_swecc-network` (same overlay as app deploys)
- `deploy-nginx.yml` — ensure `prod_nginx` is attached to `prod_swecc-network` before reload

## After merge

1. **Actions → Deploy Nginx** (syncs config + attaches network)
2. Merge swecc-core PR and run **Fix gateway DNS aliases** or redeploy bench-api/server
3. Verify: `curl -sSL https://api.swecc.org/bench/health/`

Companion PR: swecc-uw/swecc-core (fix/swag-dns-alignment)

Made with [Cursor](https://cursor.com)