### PR TITLE
fix(bench-api): ORCH_* gateway prefix in bench-api_env

### DIFF
--- a/.github/workflows/sync-configs.yml
+++ b/.github/workflows/sync-configs.yml
@@ -131,6 +131,8 @@ jobs:
           # Same Postgres as server — reuse server_env (no duplicate DB secrets).
           cp configs/server_env.txt configs/bench-api_env.txt
           cat >> configs/bench-api_env.txt << EOF
+          ORCH_GATEWAY_PREFIX=${{ secrets.ORCH_GATEWAY_PREFIX }}
+          ORCH_PUBLIC_BASE_URL=${{ secrets.ORCH_PUBLIC_BASE_URL }}
           ORCH_TRACE_DIR=/data/traces
           ORCH_SANDBOX_URL=http://bench-sandbox:8001
           ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `ORCH_GATEWAY_PREFIX` and `ORCH_PUBLIC_BASE_URL` to `bench-api_env` via sync-configs (from GitHub secrets).
- Matches [swecc-core #25](https://github.com/swecc-uw/swecc-core/pull/25) — no nginx changes, no `ROOT_PATH`.

## Secrets to set

| Secret | Example |
|--------|---------|
| `ORCH_GATEWAY_PREFIX` | `/bench` |
| *or* `ORCH_PUBLIC_BASE_URL` | `https://api.swecc.org/bench` |

## Test plan

- [ ] Run **Sync Configs** after merge
- [ ] Deploy bench-api (swecc-core #25)
- [ ] `https://api.swecc.org/bench/docs` loads Swagger