### PR TITLE
fix(deploy-nginx): detect overlay network by ID not name

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -44,15 +44,9 @@ jobs:
       - name: Attach prod nginx to app overlay network
         run: |
           set -euo pipefail
-          APP_NETWORK="${APP_NETWORK:-prod_swecc-network}"
-          if docker service inspect "${{ env.SERVICE_NAME }}" \
-            --format '{{range .Spec.TaskTemplate.Networks}}{{.Target}}{{println}}{{end}}' \
-            | grep -qx "$APP_NETWORK"; then
-            echo "✅ ${{ env.SERVICE_NAME }} already on $APP_NETWORK"
-          else
-            echo "Adding $APP_NETWORK to ${{ env.SERVICE_NAME }}..."
-            docker service update --network-add "name=${APP_NETWORK}" "${{ env.SERVICE_NAME }}"
-          fi
+          # shellcheck source=scripts/nginx-mount-path.sh
+          . ./scripts/nginx-mount-path.sh
+          ensure_service_on_network "${{ env.SERVICE_NAME }}" "${APP_NETWORK:-prod_swecc-network}"
 
       - name: Reload prod nginx
         run: |

--- a/scripts/nginx-mount-path.sh
+++ b/scripts/nginx-mount-path.sh
@@ -102,3 +102,45 @@ sync_nginx_conf_to_service_mount() {
 
   echo "OK: synced nginx.conf includes /bench/ routes"
 }
+
+# Attach overlay network if missing. Swarm stores network IDs in .Target, not names —
+# comparing Target to prod_swecc-network always fails and breaks set -e on --network-add.
+service_on_network() {
+  local service_name="${1:?service name required}"
+  local network_name="${2:?network name required}"
+  local target net_name
+
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    net_name="$(docker network inspect "$target" --format '{{.Name}}' 2>/dev/null || true)"
+    if [[ "$net_name" == "$network_name" ]]; then
+      return 0
+    fi
+  done < <(
+    docker service inspect "$service_name" \
+      --format '{{range .Spec.TaskTemplate.Networks}}{{.Target}}{{println}}{{end}}'
+  )
+  return 1
+}
+
+ensure_service_on_network() {
+  local service_name="${1:?service name required}"
+  local network_name="${2:-prod_swecc-network}"
+
+  if service_on_network "$service_name" "$network_name"; then
+    echo "OK: $service_name already on $network_name"
+    return 0
+  fi
+
+  echo "Adding $network_name to $service_name..."
+  local out
+  if out="$(docker service update --network-add "name=${network_name}" "$service_name" 2>&1)"; then
+    return 0
+  fi
+  if echo "$out" | grep -qiE 'already attached to network|service is already attached'; then
+    echo "OK: $network_name already attached ($service_name)"
+    return 0
+  fi
+  echo "$out" >&2
+  return 1
+}


### PR DESCRIPTION
## Summary

- Fix **Deploy Nginx** failing when `prod_nginx` is already on `prod_swecc-network` (Swarm stores network IDs in `.Target`, not names; the old grep always ran `--network-add`, which exited 1 under `set -euo pipefail`).
- Add `ensure_service_on_network` helper in `scripts/nginx-mount-path.sh` and use it from the workflow.

## Verification (workflow_dispatch on `navneeth-patches`)

| Workflow | Run | Result |
|----------|-----|--------|
| Deploy Gateway | [26467905900](https://github.com/swecc-uw/swecc-infra/actions/runs/26467905900) | success |
| Deploy Nginx | [26467907173](https://github.com/swecc-uw/swecc-infra/actions/runs/26467907173) | success |
| Sync Docker Configs | [26467908736](https://github.com/swecc-uw/swecc-infra/actions/runs/26467908736) | success |

Prod smoke: `https://api.swecc.org/health/` → 200 after gateway deploy.

## Test plan

- [x] Deploy Gateway workflow_dispatch
- [x] Deploy Nginx workflow_dispatch
- [x] Sync Docker Configs workflow_dispatch

Made with [Cursor](https://cursor.com)