### PR TITLE
fix(gateway): restore public api.swecc.org and harden deploy checks

### DIFF
--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -1,5 +1,4 @@
-# Config sync + force reload for an existing prod_nginx service.
-# To (re)publish :80/:443 or bootstrap the stack, use deploy-gateway.yml instead.
+# Config sync + roll for prod_nginx. Full stack repair: deploy-gateway.yml
 
 name: Deploy Nginx
 
@@ -8,11 +7,16 @@ on:
     branches: [main, master]
     paths:
       - 'nginx.conf'
+      - 'scripts/deploy-gateway.sh'
+      - 'scripts/nginx-mount-path.sh'
       - '.github/workflows/deploy-nginx.yml'
+      - '.github/workflows/deploy-gateway.yml'
   workflow_dispatch:
 
 env:
+  STACK_NAME: prod
   SERVICE_NAME: prod_nginx
+  APP_NETWORK: prod_swecc-network
 
 jobs:
   deploy_to_swarm:
@@ -24,66 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-
-      - name: Sync nginx.conf to prod bind mount
+      - name: Deploy gateway (sync config, roll, verify public :443)
         run: |
-          set -euo pipefail
-          # shellcheck source=scripts/nginx-mount-path.sh
-          . ./scripts/nginx-mount-path.sh
-
-          if ! docker service inspect "${{ env.SERVICE_NAME }}" &>/dev/null; then
-            echo "❌ Service ${{ env.SERVICE_NAME }} not found on this swarm."
-            docker service ls
-            exit 1
-          fi
-
-          sync_nginx_conf_to_service_mount "${{ env.SERVICE_NAME }}" nginx.conf
-
-      - name: Attach prod nginx to app overlay network
-        run: |
-          set -euo pipefail
-          # shellcheck source=scripts/nginx-mount-path.sh
-          . ./scripts/nginx-mount-path.sh
-          ensure_service_on_network "${{ env.SERVICE_NAME }}" "${APP_NETWORK:-prod_swecc-network}"
-
-      - name: Reload prod nginx
-        run: |
-          set -euo pipefail
-
-          echo "Reloading ${{ env.SERVICE_NAME }}..."
-          docker service update \
-            --force \
-            --update-parallelism 1 \
-            --update-order start-first \
-            --update-failure-action rollback \
-            "${{ env.SERVICE_NAME }}"
-
-      - name: Verify deployment
-        run: |
-          set -euo pipefail
-
-          echo "Waiting for ${{ env.SERVICE_NAME }} to stabilize..."
-          sleep 5
-
-          timeout=120
-          elapsed=0
-
-          while [ $elapsed -lt $timeout ]; do
-            REPLICAS=$(docker service ls --filter "name=${{ env.SERVICE_NAME }}" --format "{{.Replicas}}")
-            echo "Current replica status: $REPLICAS"
-
-            if echo "$REPLICAS" | grep -qE '^[1-9][0-9]*/[1-9][0-9]*$'; then
-              echo "✅ ${{ env.SERVICE_NAME }} is running"
-              exit 0
-            fi
-
-            echo "⏳ Waiting... ($elapsed/$timeout seconds)"
-            sleep 10
-            elapsed=$((elapsed + 10))
-          done
-
-          echo "❌ Deployment verification timed out"
-          docker service ps "${{ env.SERVICE_NAME }}" --no-trunc
-          exit 1
+          chmod +x ./scripts/deploy-gateway.sh ./scripts/nginx-mount-path.sh
+          ./scripts/deploy-gateway.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# swecc-infra
+
+Production Swarm configs, env secrets sync, and the **api.swecc.org** TLS gateway (`prod_nginx`).
+
+## What runs where
+
+| Concern | Repo | Deploy |
+|--------|------|--------|
+| App images (server, bench-api, …) | [swecc-core](https://github.com/swecc-uw/swecc-core) | `deploy-*.yml` on push to `main` |
+| Docker configs (`server_env`, …) | **this repo** | `Sync Docker Configs` (schedule + push to `main`) |
+| TLS + routing `api.swecc.org` | **this repo** | `Deploy Gateway` / `Deploy Nginx` |
+
+The live gateway is **`prod_nginx`** (stack `prod`, `nginx.conf` in this repo). It must stay on overlay **`prod_swecc-network`** with upstreams **`server:8000`**, **`bench-api:8000`**, **`sockets:8004`** (Swarm service names — not `swecc_stack_*`, which are optional aliases and break `nginx -t` when missing).
+
+Reference SWAG snippets live in swecc-core [`infra/gateway/`](https://github.com/swecc-uw/swecc-core/tree/main/infra/gateway); mirror route changes into **both** repos’ nginx configs.
+
+## Migrations vs API outages
+
+**Bench schema migrations run in the `server` image** (`manage.py migrate` in swecc-core `s/ops/deploy.sh`). **Always deploy `server` before `bench-api`** (swecc-core `deploy-bench-api.yml` already does this).
+
+- **swecc-core only** for app deploys: push to `main` on the relevant path, or run **Deploy Bench API** / **Deploy Server** manually.
+- **swecc-infra only** when changing `nginx.conf`, `stack.yml`, or env configs — not for every migration.
+
+If `api.swecc.org` is unreachable (connection refused on :443), run **Deploy Gateway** (`workflow_dispatch`) — do not redeploy bench-api until the gateway shows `1/1` and public `:443` checks pass in the job log.
+
+## Workflows
+
+- **Deploy Gateway** — stack deploy, publish :80/:443, sync `nginx.conf`, roll `prod_nginx`, verify loopback + EC2 public IP.
+- **Deploy Nginx** — same script as gateway (config-only path).
+- **Sync Docker Configs** — refresh Swarm configs; may trigger swecc-core / other service deploys when env changes.

--- a/nginx.conf
+++ b/nginx.conf
@@ -111,6 +111,15 @@ http {
             return 503 '{"status":"error","message":"WebSocket service unavailable"}';
         }
 
+        # Exact /bench (no slash): proxy instead of 301 → /bench/ (301 lacks CORS for Mesocosm).
+        location = /bench {
+            proxy_pass http://swecc_gateway_bench_api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location ^~ /bench/v1/ws/ {
             rewrite ^/bench/(.*)$ /$1 break;
             proxy_pass http://swecc_gateway_bench_api;

--- a/scripts/deploy-gateway.sh
+++ b/scripts/deploy-gateway.sh
@@ -69,16 +69,6 @@ wait_for_service() {
   die "$SERVICE_NAME did not reach Running"
 }
 
-reload_running_nginx() {
-  local cid
-  cid="$(docker ps -q -f name=prod_nginx | head -1 || true)"
-  [[ -n "$cid" ]] || return 1
-  docker exec "$cid" nginx -t
-  docker exec "$cid" nginx -s reload
-  log "reloaded nginx in container $cid"
-  return 0
-}
-
 roll_service_forward() {
   log "rolling $SERVICE_NAME forward (start-first, no rollback)"
   docker service update \
@@ -91,9 +81,20 @@ roll_service_forward() {
 
 verify_host_listeners() {
   if ! command -v ss >/dev/null 2>&1; then
-    return 0
+    die "ss required to verify :80/:443 are listening on the host"
   fi
-  ss -tln 2>/dev/null | grep -E ':80 |:443 ' || log "WARN: :80/:443 not yet in ss output"
+  local listeners
+  listeners="$(ss -tln 2>/dev/null || true)"
+  echo "$listeners" | grep -qE '(:|\*)0\.0\.0\.0:443 |\[::\]:443 |:443 ' \
+    || die ":443 is not listening on the host (prod_nginx ingress missing?)"
+  echo "$listeners" | grep -qE '(:|\*)0\.0\.0\.0:80 |\[::\]:80 |:80 ' \
+    || die ":80 is not listening on the host"
+  log "host is listening on :80 and :443"
+}
+
+verify_service_published_ports() {
+  service_has_published_port 80 || die "prod_nginx missing published port 80"
+  service_has_published_port 443 || die "prod_nginx missing published port 443"
 }
 
 verify_local_https() {
@@ -108,7 +109,28 @@ verify_local_https() {
   log "curl https://api.swecc.org/health/ via 127.0.0.1 -> HTTP $code"
   case "$code" in
     200|503) return 0 ;;
-    *) die "expected 200 or 503 from /health/, got: ${code:-none}" ;;
+    *) die "expected 200 or 503 from /health/ on loopback, got: ${code:-none}" ;;
+  esac
+}
+
+verify_public_https() {
+  if ! command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+  local public_ip code
+  public_ip="$(curl -sf --max-time 5 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
+  if [[ -z "$public_ip" ]]; then
+    log "WARN: could not read EC2 public IP; skipping public HTTPS check"
+    return 0
+  fi
+  code="$(curl -sk -o /dev/null -w '%{http_code}' \
+    --resolve "api.swecc.org:443:${public_ip}" \
+    --max-time 15 \
+    https://api.swecc.org/health/ || true)"
+  log "curl https://api.swecc.org/health/ via public IP ${public_ip} -> HTTP $code"
+  case "$code" in
+    200|503) return 0 ;;
+    *) die "public :443 check failed (got ${code:-none}); API is not reachable off-host" ;;
   esac
 }
 
@@ -139,15 +161,15 @@ main() {
   . "${REPO_ROOT}/scripts/nginx-mount-path.sh"
   sync_nginx_conf_to_service_mount "$SERVICE_NAME" nginx.conf
 
-  if reload_running_nginx; then
-    log "config applied via reload (no swarm task replace)"
-  else
-    roll_service_forward
-    wait_for_service 90
-  fi
+  # Always roll the task after a config change: reload can leave a dead master
+  # while Swarm still reports 1/1, and reload skips ingress port verification.
+  roll_service_forward
+  wait_for_service 90
 
+  verify_service_published_ports
   verify_host_listeners
   verify_local_https
+  verify_public_https
   log "gateway deploy finished OK"
 }
 

--- a/scripts/nginx-mount-path.sh
+++ b/scripts/nginx-mount-path.sh
@@ -99,8 +99,12 @@ sync_nginx_conf_to_service_mount() {
     echo "ERROR: synced file missing /bench/ routes" >&2
     return 1
   fi
+  if ! grep -qE 'location = /bench[[:space:]]*\{' "$host_path"; then
+    echo "ERROR: synced file missing exact /bench route (Mesocosm CORS)" >&2
+    return 1
+  fi
 
-  echo "OK: synced nginx.conf includes /bench/ routes"
+  echo "OK: synced nginx.conf includes /bench routes"
 }
 
 # Attach overlay network if missing. Swarm stores network IDs in .Target, not names —


### PR DESCRIPTION
## Summary
- Public API was down (connection refused on :443) while CI passed because deploy only curled `127.0.0.1`.
- Always roll `prod_nginx` after config sync; verify host listeners and EC2 public-IP HTTPS.
- Add `location = /bench` (Mesocosm CORS); route Deploy Nginx through `deploy-gateway.sh`.
- Add README with migration vs gateway deploy guidance.

## Test plan
- [ ] Merge and confirm **Deploy Gateway** / **Deploy Nginx** succeed with public IP curl in logs
- [ ] `curl -sS https://api.swecc.org/health/` returns 200 or 503 (not connection refused)
- [ ] `curl -sS https://api.swecc.org/bench/health` returns 200


Made with [Cursor](https://cursor.com)