### PR TITLE
fix(gateway): DNS/public checks; tolerate stack mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Reference SWAG snippets live in swecc-core [`infra/gateway/`](https://github.com
 - **swecc-core only** for app deploys: push to `main` on the relevant path, or run **Deploy Bench API** / **Deploy Server** manually.
 - **swecc-infra only** when changing `nginx.conf`, `stack.yml`, or env configs — not for every migration.
 
-If `api.swecc.org` is unreachable (connection refused on :443), run **Deploy Gateway** (`workflow_dispatch`) — do not redeploy bench-api until the gateway shows `1/1` and public `:443` checks pass in the job log.
+If `api.swecc.org` is unreachable (connection refused on :443), run **Deploy Gateway** (`workflow_dispatch`) — do not redeploy bench-api until the gateway shows `1/1` and public `:443` checks pass in the job log. The deploy script also fails if **Route53/DNS** does not point at this host’s public IP, or if **AWS security group** blocks inbound TCP 80/443.
 
 ## Workflows
 

--- a/scripts/deploy-gateway.sh
+++ b/scripts/deploy-gateway.sh
@@ -120,6 +120,19 @@ verify_local_https() {
   esac
 }
 
+verify_dns_points_at_this_host() {
+  if ! command -v curl >/dev/null 2>&1 || ! command -v dig >/dev/null 2>&1; then
+    return 0
+  fi
+  local public_ip dns_ip
+  public_ip="$(curl -sf --max-time 5 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
+  dns_ip="$(dig +short api.swecc.org A 2>/dev/null | head -1 || true)"
+  log "api.swecc.org DNS A=${dns_ip:-unknown}; this host public IP=${public_ip:-unknown}"
+  if [[ -n "$public_ip" && -n "$dns_ip" && "$public_ip" != "$dns_ip" ]]; then
+    die "DNS mismatch: api.swecc.org -> $dns_ip but swarm manager is $public_ip (update Route53 / elastic IP)"
+  fi
+}
+
 verify_public_https() {
   if ! command -v curl >/dev/null 2>&1; then
     return 0
@@ -137,7 +150,7 @@ verify_public_https() {
   log "curl https://api.swecc.org/health/ via public IP ${public_ip} -> HTTP $code"
   case "$code" in
     200|503) return 0 ;;
-    *) die "public :443 check failed (got ${code:-none}); API is not reachable off-host" ;;
+    *) die "public :443 check failed (got ${code:-none}); fix SG (:443 inbound), prod_nginx, or DNS" ;;
   esac
 }
 
@@ -156,7 +169,15 @@ main() {
 
   export PWD="$REPO_ROOT"
   log "stack deploy -c stack.yml $STACK_NAME (PWD=$PWD)"
-  docker stack deploy -c stack.yml "$STACK_NAME"
+  if ! stack_out="$(docker stack deploy -c stack.yml "$STACK_NAME" 2>&1)"; then
+    if echo "$stack_out" | grep -qi 'service mode change is not allowed'; then
+      log "WARN: stack deploy skipped mode change (service already exists): $stack_out"
+    else
+      die "stack deploy failed: $stack_out"
+    fi
+  else
+    log "$stack_out"
+  fi
 
   docker service inspect "$SERVICE_NAME" >/dev/null 2>&1 \
     || die "service $SERVICE_NAME not found after stack deploy"
@@ -174,9 +195,10 @@ main() {
   wait_for_service 90
 
   verify_service_published_ports
-  verify_host_listeners
+  verify_dns_points_at_this_host
   verify_local_https
   verify_public_https
+  verify_host_listeners
   log "gateway deploy finished OK"
 }
 

--- a/stack.yml
+++ b/stack.yml
@@ -12,9 +12,7 @@ services:
       - /usr/share/nginx/html:/usr/share/nginx/html
       - ${PWD}/nginx.conf:/etc/nginx/nginx.conf:ro
     deploy:
-      # One replica on a manager; global mode caused duplicate tasks (2/1) on some hosts.
-      mode: replicated
-      replicas: 1
+      mode: global
       placement:
         constraints:
           - node.role == manager


### PR DESCRIPTION
Fixes failed deploy from #26 mode change. Surfaces DNS/SG mismatch.

Made with [Cursor](https://cursor.com)