### PR TITLE
fix(gateway): stable nginx bind mount (fixes api down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Production Swarm configs, env secrets sync, and the **api.swecc.org** TLS gatewa
 | Docker configs (`server_env`, …) | **this repo** | `Sync Docker Configs` (schedule + push to `main`) |
 | TLS + routing `api.swecc.org` | **this repo** | `Deploy Gateway` / `Deploy Nginx` |
 
-The live gateway is **`prod_nginx`** (stack `prod`, `nginx.conf` in this repo). It must stay on overlay **`prod_swecc-network`** with upstreams **`server:8000`**, **`bench-api:8000`**, **`sockets:8004`** (Swarm service names — not `swecc_stack_*`, which are optional aliases and break `nginx -t` when missing).
+The live gateway is **`prod_nginx`** (stack `prod`, `nginx.conf` in this repo). Config is copied to **`/etc/nginx/swecc-api.conf`** on the swarm manager (never bind-mount the GHA workspace path). It must stay on overlay **`prod_swecc-network`** with upstreams **`server:8000`**, **`bench-api:8000`**, **`sockets:8004`** (Swarm service names — not `swecc_stack_*`, which are optional aliases and break `nginx -t` when missing).
 
 Reference SWAG snippets live in swecc-core [`infra/gateway/`](https://github.com/swecc-uw/swecc-core/tree/main/infra/gateway); mirror route changes into **both** repos’ nginx configs.
 

--- a/scripts/deploy-gateway.sh
+++ b/scripts/deploy-gateway.sh
@@ -104,20 +104,39 @@ verify_service_published_ports() {
   service_has_published_port 443 || die "prod_nginx missing published port 443"
 }
 
+ec2_public_ip() {
+  if ! command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+  local token
+  token="$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null || true)"
+  if [[ -n "$token" ]]; then
+    curl -sf -H "X-aws-ec2-metadata-token: $token" \
+      "http://169.254.169.254/latest/meta-data/public-ipv4" 2>/dev/null || true
+    return 0
+  fi
+  curl -sf --max-time 5 "http://169.254.169.254/latest/meta-data/public-ipv4" 2>/dev/null || true
+}
+
 verify_local_https() {
   if ! command -v curl >/dev/null 2>&1; then
     return 0
   fi
-  local code
-  code="$(curl -sk -o /dev/null -w '%{http_code}' \
-    --resolve api.swecc.org:443:127.0.0.1 \
-    --max-time 15 \
-    https://api.swecc.org/health/ || true)"
-  log "curl https://api.swecc.org/health/ via 127.0.0.1 -> HTTP $code"
-  case "$code" in
-    200|503) return 0 ;;
-    *) die "expected 200 or 503 from /health/ on loopback, got: ${code:-none}" ;;
-  esac
+  local attempt=0 code
+  while [[ $attempt -lt 15 ]]; do
+    code="$(curl -sk -o /dev/null -w '%{http_code}' \
+      --resolve api.swecc.org:443:127.0.0.1 \
+      --max-time 15 \
+      https://api.swecc.org/health/ || true)"
+    log "curl https://api.swecc.org/health/ via 127.0.0.1 -> HTTP $code (attempt $((attempt + 1)))"
+    case "$code" in
+      200|503) return 0 ;;
+    esac
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  die "expected 200 or 503 from /health/ on loopback, got: ${code:-none}"
 }
 
 verify_dns_points_at_this_host() {
@@ -125,7 +144,7 @@ verify_dns_points_at_this_host() {
     return 0
   fi
   local public_ip dns_ip
-  public_ip="$(curl -sf --max-time 5 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
+  public_ip="$(ec2_public_ip)"
   dns_ip="$(dig +short api.swecc.org A 2>/dev/null | head -1 || true)"
   log "api.swecc.org DNS A=${dns_ip:-unknown}; this host public IP=${public_ip:-unknown}"
   if [[ -n "$public_ip" && -n "$dns_ip" && "$public_ip" != "$dns_ip" ]]; then
@@ -138,7 +157,7 @@ verify_public_https() {
     return 0
   fi
   local public_ip code
-  public_ip="$(curl -sf --max-time 5 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)"
+  public_ip="$(ec2_public_ip)"
   if [[ -z "$public_ip" ]]; then
     log "WARN: could not read EC2 public IP; skipping public HTTPS check"
     return 0
@@ -187,7 +206,7 @@ main() {
 
   # shellcheck source=scripts/nginx-mount-path.sh
   . "${REPO_ROOT}/scripts/nginx-mount-path.sh"
-  sync_nginx_conf_to_service_mount "$SERVICE_NAME" nginx.conf
+  publish_nginx_conf_for_swarm "$SERVICE_NAME" nginx.conf
 
   # Always roll the task after a config change: reload can leave a dead master
   # while Swarm still reports 1/1, and reload skips ingress port verification.

--- a/scripts/nginx-mount-path.sh
+++ b/scripts/nginx-mount-path.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Shared helpers: resolve prod nginx bind-mount source and sync nginx.conf there.
+# Shared helpers: stable prod nginx bind mount and overlay network attach.
 set -euo pipefail
 
 NGINX_CONF_TARGET="${NGINX_CONF_TARGET:-/etc/nginx/nginx.conf}"
+# Host path prod_nginx must mount (survives GHA checkout teardown).
+HOST_NGINX_CONF="${HOST_NGINX_CONF:-/etc/nginx/swecc-api.conf}"
 
 # Swarm inspect may return Docker Desktop's /host_mnt/... prefix; map to a host path we can write.
 host_path_from_mount_source() {
@@ -12,7 +14,6 @@ host_path_from_mount_source() {
     printf '%s' "$p"
     return 0
   fi
-  # macOS: /var/... is often /private/var/...
   if [[ "$p" == /private/* && -e "${p#/private}" ]]; then
     printf '%s' "${p#/private}"
     return 0
@@ -20,7 +21,6 @@ host_path_from_mount_source() {
   printf '%s' "$p"
 }
 
-# Print the host path bind-mounted to NGINX_CONF_TARGET for a Swarm service.
 nginx_bind_mount_source() {
   local service_name="${1:?service name required}"
   local mounts_json
@@ -32,21 +32,11 @@ nginx_bind_mount_source() {
     return 1
   fi
 
-  # Prefer jq when available; fall back to a minimal grep/sed parser.
   if command -v jq >/dev/null 2>&1; then
     local source
     source="$(printf '%s' "$mounts_json" | jq -r --arg t "$NGINX_CONF_TARGET" \
       '.[] | select(.Type == "bind" and .Target == $t) | .Source' | head -n1)"
     if [[ -n "$source" && "$source" != "null" ]]; then
-      printf '%s' "$source"
-      return 0
-    fi
-  else
-    local source
-    source="$(printf '%s' "$mounts_json" | tr ',' '\n' \
-      | grep -F "\"Target\":\"$NGINX_CONF_TARGET\"" \
-      | sed -n 's/.*"Source":"\([^"]*\)".*/\1/p' | head -n1)"
-    if [[ -n "$source" ]]; then
       printf '%s' "$source"
       return 0
     fi
@@ -57,7 +47,6 @@ nginx_bind_mount_source() {
   return 1
 }
 
-# Resolve to an absolute path (Linux runners; used to detect same-file bind mounts).
 _abs_path() {
   local p="$1"
   if command -v realpath >/dev/null 2>&1; then
@@ -67,34 +56,8 @@ _abs_path() {
   fi
 }
 
-# Copy repo nginx.conf to the path the running service actually reads.
-sync_nginx_conf_to_service_mount() {
-  local service_name="${1:?service name required}"
-  local source_conf="${2:-nginx.conf}"
-
-  if [[ ! -f "$source_conf" ]]; then
-    echo "ERROR: $source_conf not found" >&2
-    return 1
-  fi
-
-  local mount_source host_path src_abs dest_abs
-  mount_source="$(nginx_bind_mount_source "$service_name")"
-  host_path="$(host_path_from_mount_source "$mount_source")"
-  src_abs="$(_abs_path "$source_conf")"
-  dest_abs="$(_abs_path "$host_path")"
-
-  echo "Service: $service_name"
-  echo "Mount source (inspect): $mount_source"
-  echo "Host path (write): $host_path"
-
-  if [[ "$src_abs" == "$dest_abs" ]]; then
-    echo "OK: bind mount already uses checkout nginx.conf (no copy needed)"
-  else
-    echo "Copying $source_conf -> $host_path"
-    mkdir -p "$(dirname "$host_path")"
-    cp "$source_conf" "$host_path"
-  fi
-
+_validate_synced_nginx() {
+  local host_path="$1"
   if ! grep -qE 'location .* /bench/' "$host_path"; then
     echo "ERROR: synced file missing /bench/ routes" >&2
     return 1
@@ -103,12 +66,49 @@ sync_nginx_conf_to_service_mount() {
     echo "ERROR: synced file missing exact /bench route (Mesocosm CORS)" >&2
     return 1
   fi
-
   echo "OK: synced nginx.conf includes /bench routes"
 }
 
-# Attach overlay network if missing. Swarm stores network IDs in .Target, not names —
-# comparing Target to prod_swecc-network always fails and breaks set -e on --network-add.
+# Write repo nginx.conf to HOST_NGINX_CONF and point prod_nginx at that path.
+publish_nginx_conf_for_swarm() {
+  local service_name="${1:?service name required}"
+  local source_conf="${2:-nginx.conf}"
+
+  if [[ ! -f "$source_conf" ]]; then
+    echo "ERROR: $source_conf not found" >&2
+    return 1
+  fi
+
+  echo "Publishing $source_conf -> $HOST_NGINX_CONF"
+  sudo mkdir -p "$(dirname "$HOST_NGINX_CONF")"
+  sudo cp "$source_conf" "$HOST_NGINX_CONF"
+  sudo chmod 644 "$HOST_NGINX_CONF"
+  _validate_synced_nginx "$HOST_NGINX_CONF"
+
+  local mount_source host_path
+  mount_source="$(nginx_bind_mount_source "$service_name")"
+  host_path="$(host_path_from_mount_source "$mount_source")"
+
+  echo "Service: $service_name"
+  echo "Current mount source: $mount_source"
+
+  if [[ "$host_path" == "$(_abs_path "$HOST_NGINX_CONF")" ]]; then
+    echo "OK: service already mounts $HOST_NGINX_CONF"
+    return 0
+  fi
+
+  echo "Updating $service_name bind mount -> $HOST_NGINX_CONF"
+  docker service update \
+    --mount-rm "$NGINX_CONF_TARGET" \
+    --mount-add "type=bind,source=${HOST_NGINX_CONF},target=${NGINX_CONF_TARGET},readonly" \
+    "$service_name"
+}
+
+# Back-compat name used by older scripts.
+sync_nginx_conf_to_service_mount() {
+  publish_nginx_conf_for_swarm "$@"
+}
+
 service_on_network() {
   local service_name="${1:?service name required}"
   local network_name="${2:?network name required}"

--- a/stack.yml
+++ b/stack.yml
@@ -10,7 +10,8 @@ services:
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
       - /usr/share/nginx/html:/usr/share/nginx/html
-      - ${PWD}/nginx.conf:/etc/nginx/nginx.conf:ro
+      # Stable host path (not GHA workspace); deploy-gateway copies repo nginx.conf here.
+      - /etc/nginx/swecc-api.conf:/etc/nginx/nginx.conf:ro
     deploy:
       mode: global
       placement:


### PR DESCRIPTION
## Root cause
prod_nginx mounted `nginx.conf` from the GHA workspace; external and loopback :443 died when that path was invalid.

## Fix
- Copy to `/etc/nginx/swecc-api.conf` and update Swarm mount
- IMDSv2 for public IP checks; retry health curl

Made with [Cursor](https://cursor.com)