### PR TITLE
feat(sync-configs): bench RabbitMQ env for api and worker

### DIFF
--- a/.github/workflows/sync-configs.yml
+++ b/.github/workflows/sync-configs.yml
@@ -128,13 +128,17 @@ jobs:
 
       - name: Create Bench API Config
         run: |
-          # Same Postgres as server — reuse server_env (no duplicate DB secrets).
+          # Same Postgres as server — reuse server_env (RABBIT_HOST/PORT/VHOST + DB_*).
+          # Bench MQ uses dedicated BENCH_RABBIT_* creds (see s/ops/rabbitmq.sh in swecc-core).
           cp configs/server_env.txt configs/bench-api_env.txt
           cat >> configs/bench-api_env.txt << EOF
           ORCH_GATEWAY_PREFIX=${{ secrets.ORCH_GATEWAY_PREFIX }}
           ORCH_PUBLIC_BASE_URL=${{ secrets.ORCH_PUBLIC_BASE_URL }}
           ORCH_TRACE_DIR=/data/traces
           ORCH_SANDBOX_URL=http://bench-sandbox:8001
+          BENCH_RABBIT_USER=${{ secrets.BENCH_RABBIT_USER }}
+          BENCH_RABBIT_PASS=${{ secrets.BENCH_RABBIT_PASS }}
+          ORCH_MQ_ENABLED=0
           ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GEMINI_API_KEY }}
@@ -151,6 +155,18 @@ jobs:
           cat > configs/bench-worker_env.txt << EOF
           WORKER_API_URL=http://bench-api:8000
           WORKER_POLL_INTERVAL=10
+          DB_HOST=${{ secrets.DB_HOST }}
+          DB_NAME=${{ secrets.DB_NAME }}
+          DB_PORT=${{ secrets.DB_PORT }}
+          DB_USER=${{ secrets.DB_USER }}
+          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          RABBIT_HOST=${{ secrets.RABBIT_HOST }}
+          RABBIT_PORT=${{ secrets.RABBIT_PORT }}
+          RABBIT_VHOST=${{ secrets.RABBIT_VHOST }}
+          BENCH_RABBIT_USER=${{ secrets.BENCH_RABBIT_USER }}
+          BENCH_RABBIT_PASS=${{ secrets.BENCH_RABBIT_PASS }}
+          ORCH_MQ_ENABLED=0
           ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY=${{ secrets.GEMINI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ If `api.swecc.org` is unreachable (connection refused on :443), run **Deploy Gat
 - **Deploy Gateway** — stack deploy, publish :80/:443, sync `nginx.conf`, roll only when config/ports change (one job at a time via concurrency).
 - **Deploy Nginx** — manual `workflow_dispatch` only (do not duplicate push triggers).
 - **Sync Docker Configs** — refresh Swarm configs; may trigger swecc-core / other service deploys when env changes.
+
+### Bench RabbitMQ (optional dispatch)
+
+`bench-api_env` / `bench-worker_env` include `BENCH_RABBIT_USER`, `BENCH_RABBIT_PASS`, and `ORCH_MQ_ENABLED=0` (MQ off until you intentionally enable it). Set repo secrets before the next sync:
+
+```bash
+gh secret set BENCH_RABBIT_USER --repo swecc-uw/swecc-infra --body-file /path/to/user.txt
+gh secret set BENCH_RABBIT_PASS --repo swecc-uw/swecc-infra --body-file /path/to/pass.txt
+```
+
+After merge, run **Sync Docker Configs**, then on the swarm manager provision the Rabbit user: `s/ops/rabbitmq.sh bench-api` (from [swecc-core](https://github.com/swecc-uw/swecc-core)). Pairs with [swecc-core#62](https://github.com/swecc-uw/swecc-core/pull/62).


### PR DESCRIPTION
## Summary

- Adds `BENCH_RABBIT_USER` / `BENCH_RABBIT_PASS` to **`bench-api_env`** (appended after `server_env` copy, which already includes `RABBIT_HOST` / `RABBIT_PORT` / `RABBIT_VHOST`).
- Expands **`bench-worker_env`** with `DB_*`, `JWT_SECRET`, Rabbit connection vars, and the same bench Rabbit creds (required for MQ mode and Django ORM bootstrap).
- Sets **`ORCH_MQ_ENABLED=0`** in both configs so prod stays on legacy HTTP/async dispatch until ops explicitly enable MQ.

Pairs with [swecc-core#62](https://github.com/swecc-uw/swecc-core/pull/62) (bench RabbitMQ code paths).

## Before merging / running Sync Docker Configs

Set GitHub secrets on **this repo** (not committed to git):

```bash
gh secret set BENCH_RABBIT_USER --repo swecc-uw/swecc-infra --body-file /path/to/user.txt
gh secret set BENCH_RABBIT_PASS --repo swecc-uw/swecc-infra --body-file /path/to/pass.txt
```

Use dedicated Rabbit credentials (same pattern as `SERVER_RABBIT_*` / `AI_RABBIT_*`), not `guest`.

## After merge

1. Merge this PR → **Sync Docker Configs** runs (or dispatch manually).
2. On swarm manager: `./s/ops/rabbitmq.sh bench-api` from swecc-core (provisions the bench Rabbit user).
3. Deploy bench-api / bench-worker from swecc-core when ready.
4. **Do not** set `ORCH_MQ_ENABLED=1` until shared trace volume, worker token, and smoke tests are done.

## Test plan

- [ ] Confirm `BENCH_RABBIT_*` secrets exist on `swecc-uw/swecc-infra` before first post-merge sync
- [ ] After sync, `docker config inspect bench-api_env` includes `BENCH_RABBIT_USER` (value redacted)
- [ ] `bench-worker_env` includes `DB_HOST`, `JWT_SECRET`, `ORCH_MQ_ENABLED=0`
- [ ] Run `rabbitmq.sh bench-api` on prod swarm
- [ ] Verify bench-api/worker still healthy with `ORCH_MQ_ENABLED=0`


Made with [Cursor](https://cursor.com)